### PR TITLE
add flags to remove user and roles from pg dump

### DIFF
--- a/src/pg/dump.ts
+++ b/src/pg/dump.ts
@@ -2,7 +2,7 @@ import {spawn} from 'child_process';
 import {gracefulShutdown} from '../utils/handlers.js';
 
 export function createPgDump(connectionUrl: string) {
-  const pg = spawn('pg_dump', [connectionUrl]);
+  const pg = spawn('pg_dump', [connectionUrl, '--no-privileges', '--no-owner']);
 
   pg.on('exit', (code) => {
     if (code !== 0) {


### PR DESCRIPTION
### Description
pgfaker uses `pg_dump` to dump everything from the database. We however don't require the roles and owner information to be copied over because when we load this dump into fresh clean database, we get warnings such as `role doesn't exist`. 

This change makes the internal `pg_dump` fork not emit these information.